### PR TITLE
Enable the Oculus XR Plugin in Unity settings.

### DIFF
--- a/Assets/Resources/OculusPlatformSettings.asset
+++ b/Assets/Resources/OculusPlatformSettings.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b3d881e962d099f4a8eb492ef7e9a8c0, type: 3}
+  m_Name: OculusPlatformSettings
+  m_EditorClassIdentifier: 
+  ovrAppID: 
+  ovrMobileAppID: 
+  ovrUseStandalonePlatform: 0

--- a/Assets/Resources/OculusPlatformSettings.asset.meta
+++ b/Assets/Resources/OculusPlatformSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b9dec9d402f8db5459a40a6e0c762a67
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/XR/XRGeneralSettings.asset
+++ b/Assets/XR/XRGeneralSettings.asset
@@ -1,5 +1,19 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-8316951663053129122
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d236b7d11115f2143951f1e14045df39, type: 3}
+  m_Name: Standalone Settings
+  m_EditorClassIdentifier: 
+  m_LoaderManagerInstance: {fileID: 9052326817036235960}
+  m_InitManagerOnStart: 1
 --- !u!114 &-1597897047829718794
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -29,9 +43,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d2dc886499c26824283350fa532d087d, type: 3}
   m_Name: XRGeneralSettings
   m_EditorClassIdentifier: 
-  Keys: 07000000
+  Keys: 0700000001000000
   Values:
   - {fileID: 1572561425071505428}
+  - {fileID: -8316951663053129122}
 --- !u!114 &1572561425071505428
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -46,3 +61,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_LoaderManagerInstance: {fileID: -1597897047829718794}
   m_InitManagerOnStart: 1
+--- !u!114 &9052326817036235960
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4c3631f5e58749a59194e0cf6baf6d5, type: 3}
+  m_Name: Standalone Providers
+  m_EditorClassIdentifier: 
+  m_RequiresSettingsUpdate: 0
+  m_AutomaticLoading: 0
+  m_AutomaticRunning: 0
+  m_Loaders:
+  - {fileID: 11400000, guid: c3617be682b7a79428ea5335f93cc4c6, type: 2}


### PR DESCRIPTION
When first opening the repository in Unity and hitting play, it does not go into VR mode. This is because the Oculus Plugin for UnityXR is disabled in Project settings. This pull request enables the Oculus Plugin for Unity XR.